### PR TITLE
remove fuse website from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": ["@fuse-examples/*"],
+  "ignore": ["@fuse-examples/*", "@fuse/website"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true,
     "updateInternalDependents": "out-of-range"

--- a/.changeset/shaggy-cheetahs-walk.md
+++ b/.changeset/shaggy-cheetahs-walk.md
@@ -1,5 +1,0 @@
----
-'@fuse/website': patch
----
-
-Adds fuse.js website with docs. Built using NextJS and Nextra.


### PR DESCRIPTION
Keeping changesets exclusively for publishing the core (and in the future other) packages to npm.