### PR TITLE
fix(create-fuse-app): check for the `/src/app` when src is found

### DIFF
--- a/.changeset/slow-dryers-cross.md
+++ b/.changeset/slow-dryers-cross.md
@@ -1,0 +1,5 @@
+---
+'create-fuse-app': patch
+---
+
+Check for `src` when looking for the `/app` directory

--- a/packages/create-fuse-app/src/index.ts
+++ b/packages/create-fuse-app/src/index.ts
@@ -72,7 +72,9 @@ async function createFuseApp() {
   // Create initial types and API-Route
   s.start('Creating API Route...')
   const isUsingSrc = existsSync(resolve(targetDir, 'src'))
-  const shouldUseAppDir = existsSync(resolve(targetDir, 'app'))
+  const shouldUseAppDir = existsSync(
+    isUsingSrc ? resolve(targetDir, 'src', 'app') : resolve(targetDir, 'app'),
+  )
   const apiRouteSnippet = createSnippet(shouldUseAppDir)
 
   if (isUsingSrc) {


### PR DESCRIPTION
Fixes #97 