### PR TITLE
feat(core): export client entry from `fuse/client.ts`

### DIFF
--- a/.changeset/mighty-lobsters-whisper.md
+++ b/.changeset/mighty-lobsters-whisper.md
@@ -1,0 +1,5 @@
+---
+'fuse': minor
+---
+
+Export the fuse standalone `/client` from `fuse/client.ts`

--- a/examples/standalone/fuse/index.ts
+++ b/examples/standalone/fuse/index.ts
@@ -1,2 +1,3 @@
 export * from './fragment-masking'
 export * from './gql'
+export * from 'fuse/client'

--- a/examples/standalone/src/App.tsx
+++ b/examples/standalone/src/App.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import { useQuery } from 'fuse/client'
 
-import { graphql } from '../fuse'
+import { graphql, useQuery } from '../fuse'
 import { LaunchItem } from './components/LaunchItem'
 import { PageNumbers } from './components/PageNumbers'
 import { LaunchDetails } from './components/LaunchDetails'

--- a/examples/standalone/src/components/LaunchDetails.tsx
+++ b/examples/standalone/src/components/LaunchDetails.tsx
@@ -1,6 +1,4 @@
-import { useQuery } from 'fuse/client'
-
-import { graphql } from '../../fuse'
+import { graphql, useQuery } from '../../fuse'
 import { LaunchSite } from './LaunchSite'
 
 const LaunchDetailsQuery = graphql(`

--- a/examples/standalone/src/main.tsx
+++ b/examples/standalone/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { createClient, Provider } from 'fuse/client'
+import { createClient, Provider } from '../fuse'
 import App from './App.tsx'
 import './index.css'
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import sade from 'sade'
 import path from 'path'
-import fs from 'fs/promises'
+import fs, { appendFile } from 'fs/promises'
 import { createServer, build } from 'vite'
 import { VitePluginNode } from 'vite-plugin-node'
 import { generate, CodegenContext } from '@graphql-codegen/cli'
@@ -211,5 +211,13 @@ async function boostrapCodegen(location: string, watch: boolean) {
       },
     },
   })
-  return generate(ctx, true)
+
+  await generate(ctx, true)
+
+  console.log('\n\n\n\n\nWAT\n\n\n\n\n')
+
+  await appendFile(
+    baseDirectory + '/fuse' + '/index.ts',
+    '\nexport * from "fuse/client"',
+  )
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -214,8 +214,6 @@ async function boostrapCodegen(location: string, watch: boolean) {
 
   await generate(ctx, true)
 
-  console.log('\n\n\n\n\nWAT\n\n\n\n\n')
-
   await appendFile(
     baseDirectory + '/fuse' + '/index.ts',
     '\nexport * from "fuse/client"',


### PR DESCRIPTION
Standalone requires a user to do these imports; that feels unintuitive because useFragment appears to be at the same level of abstraction as useQuery, and yet they have to import them from two different places:

```ts
import { useQuery } from 'fuse/client'
import { graphql, useFragment } from '../../fuse'
```

This PR adds `export * from 'fuse/client'` to `@/fuse/index.ts` so that the imports can instead be centralized:

```ts
import { graphql, useFragment, useQuery } from '../../fuse'
```