### PR TITLE
feat(core): add initial datasources design

### DIFF
--- a/.changeset/six-pandas-cry.md
+++ b/.changeset/six-pandas-cry.md
@@ -1,0 +1,5 @@
+---
+'fuse': minor
+---
+
+Re-introduce the concept of datasources

--- a/packages/core/src/datasources/index.ts
+++ b/packages/core/src/datasources/index.ts
@@ -1,0 +1,28 @@
+export type Key = string | number
+
+export interface Datasource<T extends {}> {
+  getMany?(ids: Key[], ctx: any): Promise<Array<T>> | Array<T>
+}
+
+/**
+ * A datasource is a way to fetch data from a remote source. It can be a REST API, a database, an
+ * external third party service, etc. All that's needed is to extend the class and pass it to a node.
+ *
+ * @example
+ * ```ts
+ * class RestDatasource extends Datasource<T> {
+ *   getMany(ids: Key[], ctx: any): Promise<Array<T>> | Array<T> {
+ *     // getMany is optional, however using it has a performance benefit.
+ *     // a node will be able to resolve all the ids in a single request rather
+ *     // than n (being the amount of ids) requests.
+ *   }
+ *
+ *   getOne(id: Key, ctx: any): Promise<T> | T {
+ *     return fetch().then(x => x.json())
+ *   }
+ * }
+ * ```
+ */
+export abstract class Datasource<T extends {}> {
+  abstract getOne(id: Key, ctx: any): Promise<T> | T
+}


### PR DESCRIPTION
Resolve #89 

## Summary

The idea here is that we allow folks to create their own implementation of a `Datasource` all that it needs is to inherit from `Datasource` and we'll be able to use it in `node`. A datasource has to implement `getOne` and optionally can choose to supply `getMany` if their endpoint supports that.

A `node` is still allowed to supply the `load` function itself, the concept of datasources can be used to facilitate a wider ecosystem where folks can export i.e. `fuse-shopify` where there are a number of `datasources` and types exported that can be used in `node`/... folks can then choose to remap those properties to their own names or just use them as-is.