### PR TITLE
feat(core): authorization on fields and types

### DIFF
--- a/.changeset/moody-singers-approve.md
+++ b/.changeset/moody-singers-approve.md
@@ -1,0 +1,5 @@
+---
+'fuse': minor
+---
+
+Implement scope-based authorization model for `fuse`

--- a/examples/spacex/app/api/fuse/route.ts
+++ b/examples/spacex/app/api/fuse/route.ts
@@ -1,6 +1,8 @@
 import { createAPIRouteHandler } from 'fuse/next'
 
-const layer = createAPIRouteHandler()
+const layer = createAPIRouteHandler({
+  context: (req) => ({ user: true }),
+})
 
 export const GET = layer
 export const POST = layer

--- a/examples/spacex/app/rsc/page.tsx
+++ b/examples/spacex/app/rsc/page.tsx
@@ -32,6 +32,7 @@ export default async function Page({
   const result = await execute({
     query: LaunchesQuery,
     variables: { limit: 10, offset },
+    context: () => ({ user: true }),
   })
 
   return (

--- a/examples/spacex/schema.graphql
+++ b/examples/spacex/schema.graphql
@@ -46,7 +46,7 @@ type Query {
 }
 
 type QueryLaunchesList {
-  nodes: [Launch!]!
+  nodes: [Launch]!
   totalCount: Int
 }
 

--- a/examples/spacex/tsconfig.json
+++ b/examples/spacex/tsconfig.json
@@ -32,6 +32,12 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "./types/scopes.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/examples/spacex/tsconfig.json
+++ b/examples/spacex/tsconfig.json
@@ -37,7 +37,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "./types/scopes.ts"
+    "types/scopes.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/examples/spacex/types/Launch.ts
+++ b/examples/spacex/types/Launch.ts
@@ -1,10 +1,4 @@
-import {
-  node,
-  NotFoundError,
-  addQueryFields,
-  addMutationFields,
-  addAuthScope,
-} from 'fuse'
+import { node, NotFoundError, addQueryFields, addMutationFields } from 'fuse'
 
 // The type we expect from the API
 interface Launch {
@@ -16,8 +10,6 @@ interface Launch {
   launch_site: { site_id: string }
   links: { mission_patch: string }
 }
-
-addAuthScope('isLoggedIn', () => true)
 
 export const LaunchNode = node<Launch>({
   name: 'Launch',

--- a/examples/spacex/types/Launch.ts
+++ b/examples/spacex/types/Launch.ts
@@ -1,4 +1,11 @@
-import { node, NotFoundError, addQueryFields, addMutationFields } from 'fuse'
+import {
+  node,
+  NotFoundError,
+  addQueryFields,
+  addMutationFields,
+  addAuthScope,
+  Scopes,
+} from 'fuse'
 
 // The type we expect from the API
 interface Launch {

--- a/examples/spacex/types/Launch.ts
+++ b/examples/spacex/types/Launch.ts
@@ -1,11 +1,4 @@
-import {
-  node,
-  NotFoundError,
-  addQueryFields,
-  addMutationFields,
-  addAuthScope,
-  Scopes,
-} from 'fuse'
+import { node, NotFoundError, addQueryFields, addMutationFields } from 'fuse'
 
 // The type we expect from the API
 interface Launch {

--- a/examples/spacex/types/Launch.ts
+++ b/examples/spacex/types/Launch.ts
@@ -1,4 +1,10 @@
-import { node, NotFoundError, addQueryFields, addMutationFields } from 'fuse'
+import {
+  node,
+  NotFoundError,
+  addQueryFields,
+  addMutationFields,
+  addAuthScope,
+} from 'fuse'
 
 // The type we expect from the API
 interface Launch {
@@ -10,6 +16,8 @@ interface Launch {
   launch_site: { site_id: string }
   links: { mission_patch: string }
 }
+
+addAuthScope('isLoggedIn', () => true)
 
 export const LaunchNode = node<Launch>({
   name: 'Launch',
@@ -65,6 +73,9 @@ addQueryFields((t) => ({
   launches: t.list({
     type: LaunchNode,
     nullable: false,
+    authScopes: {
+      isLoggedIn: true,
+    },
     nodeNullable: true,
     args: {
       offset: t.arg.int(),

--- a/examples/spacex/types/scopes.ts
+++ b/examples/spacex/types/scopes.ts
@@ -7,4 +7,4 @@ declare module 'fuse' {
   }
 }
 
-defineAuthScopes<Scopes>((ctx) => ({ isLoggedIn: !!ctx.user }))
+defineAuthScopes((ctx) => ({ isLoggedIn: !!ctx.user }))

--- a/examples/spacex/types/scopes.ts
+++ b/examples/spacex/types/scopes.ts
@@ -1,5 +1,5 @@
 import 'fuse'
-import { addAuthScope, Scopes } from 'fuse'
+import { addAuthScopes, Scopes } from 'fuse'
 
 declare module 'fuse' {
   export interface Scopes {
@@ -7,7 +7,4 @@ declare module 'fuse' {
   }
 }
 
-addAuthScope<Scopes['isLoggedIn']>(
-  'isLoggedIn',
-  (ctx) => ctx.user !== undefined,
-)
+addAuthScopes<Scopes>((ctx) => ({ isLoggedIn: !!ctx.user }))

--- a/examples/spacex/types/scopes.ts
+++ b/examples/spacex/types/scopes.ts
@@ -1,7 +1,10 @@
 import 'fuse'
+import { addAuthScope } from 'fuse'
 
 declare module 'fuse' {
   export interface Scopes {
     isLoggedIn: boolean
   }
 }
+
+addAuthScope('isLoggedIn', (ctx) => ctx.user !== undefined)

--- a/examples/spacex/types/scopes.ts
+++ b/examples/spacex/types/scopes.ts
@@ -1,5 +1,5 @@
 import 'fuse'
-import { addAuthScope } from 'fuse'
+import { addAuthScope, Scopes } from 'fuse'
 
 declare module 'fuse' {
   export interface Scopes {
@@ -7,4 +7,7 @@ declare module 'fuse' {
   }
 }
 
-addAuthScope('isLoggedIn', (ctx) => ctx.user !== undefined)
+addAuthScope<Scopes['isLoggedIn']>(
+  'isLoggedIn',
+  (ctx) => ctx.user !== undefined,
+)

--- a/examples/spacex/types/scopes.ts
+++ b/examples/spacex/types/scopes.ts
@@ -1,5 +1,5 @@
 import 'fuse'
-import { addAuthScopes, Scopes } from 'fuse'
+import { defineAuthScopes, Scopes } from 'fuse'
 
 declare module 'fuse' {
   export interface Scopes {
@@ -7,4 +7,4 @@ declare module 'fuse' {
   }
 }
 
-addAuthScopes<Scopes>((ctx) => ({ isLoggedIn: !!ctx.user }))
+defineAuthScopes<Scopes>((ctx) => ({ isLoggedIn: !!ctx.user }))

--- a/examples/spacex/types/scopes.ts
+++ b/examples/spacex/types/scopes.ts
@@ -1,0 +1,7 @@
+import 'fuse'
+
+declare module 'fuse' {
+  export interface Scopes {
+    isLoggedIn: boolean
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,7 @@
     "@pothos/core": "^3.38.0",
     "@pothos/plugin-dataloader": "^3.17.1",
     "@pothos/plugin-relay": "^3.44.0",
+    "@pothos/plugin-scope-auth": "^3.20.0",
     "@urql/core": "^4.2.0",
     "@urql/next": "^1.1.0",
     "aws-lambda": "^1.0.7",

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -88,7 +88,7 @@ const builder = new SchemaBuilder<{
   },
 })
 
-export const defineAuthScopes = <Scopes>(
+export const defineAuthScopes = (
   func: (ctx: any) => Promise<Scopes> | Scopes,
 ) => {
   scopesFunc = func

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -88,7 +88,7 @@ const builder = new SchemaBuilder<{
   },
 })
 
-export const addAuthScopes = <Scopes>(
+export const defineAuthScopes = <Scopes>(
   func: (ctx: any) => Promise<Scopes> | Scopes,
 ) => {
   scopesFunc = func

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -67,9 +67,9 @@ const builder = new SchemaBuilder<{
   },
 })
 
-export const addAuthScope = <Name extends keyof Scopes>(
-  name: Name,
-  scope: (context: any) => Promise<Scopes[Name]> | Scopes[Name],
+export const addAuthScope = <ReturnValue>(
+  name: string,
+  scope: (context: any) => Promise<ReturnValue> | ReturnValue,
 ) => {
   scopes[name] = scope
 }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -29,6 +29,7 @@ export type {
   InitialContext,
   StellateOptions,
 } from './utils/yoga-helpers'
+import { ForbiddenError } from './errors'
 
 export interface Scopes {}
 
@@ -53,6 +54,9 @@ const builder = new SchemaBuilder<{
   defaultFieldNullability: true,
   authScopes: async (context) => {
     return await scopesFunc(context)
+  },
+  scopeAuthOptions: {
+    unauthorizedError: () => new ForbiddenError('Not authorized'),
   },
   relayOptions: {
     clientMutationId: 'omit',

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -54,10 +54,11 @@ const builder = new SchemaBuilder<{
   authScopes: async (context) => {
     const keys = Object.keys(scopes)
     const output = {}
-    for (const key in keys) {
+    for (const key of keys) {
       const scope = scopes[key]
       output[key] = await scope(context)
     }
+
     return output
   },
   relayOptions: {

--- a/packages/core/test/authorization.test.ts
+++ b/packages/core/test/authorization.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from 'vitest'
+import { execute, parse } from 'graphql'
+
+let counter = 0
+const importFuse = () => {
+  return import('../src/builder?test-authorization=' + counter++)
+}
+
+test('Should correctly format an authentication error', async () => {
+  const mod = await importFuse()
+  const { builder, addQueryFields, addAuthScopes } = mod
+  addAuthScopes((ctx) => ({ isLoggedIn: !!ctx.user }))
+
+  addQueryFields((t) => ({
+    isLoggedIn: t.field({
+      type: 'Boolean',
+      description: 'An authentication check',
+      authScopes: {
+        isLoggedIn: true,
+      },
+      resolve: () => {
+        return true
+      },
+    }),
+  }))
+
+  const schema = builder.toSchema()
+
+  const document = parse(`query { isLoggedIn }`)
+  let result = (await execute({
+    document,
+    schema,
+    contextValue: {},
+  })) as { data?: any; errors?: any }
+
+  expect(result.data).toEqual({ isLoggedIn: null })
+  expect(result.errors).toBeDefined()
+  expect(result.errors).toHaveLength(1)
+  expect(result.errors[0].message).toEqual('Not authorized')
+  expect(result.errors[0].extensions).toEqual({
+    code: 'FORBIDDEN',
+  })
+
+  result = (await execute({
+    document,
+    schema,
+    contextValue: {
+      user: true,
+    },
+  })) as { data?: any; errors?: any }
+
+  expect(result.data).toEqual({ isLoggedIn: true })
+})

--- a/packages/core/test/authorization.test.ts
+++ b/packages/core/test/authorization.test.ts
@@ -6,7 +6,7 @@ const importFuse = () => {
   return import('../src/builder?test-authorization=' + counter++)
 }
 
-test('Should correctly format an authentication error', async () => {
+test('Should correctly do top-level field authorization', async () => {
   const mod = await importFuse()
   const { builder, addQueryFields, addAuthScopes } = mod
   addAuthScopes((ctx) => ({ isLoggedIn: !!ctx.user }))
@@ -50,4 +50,168 @@ test('Should correctly format an authentication error', async () => {
   })) as { data?: any; errors?: any }
 
   expect(result.data).toEqual({ isLoggedIn: true })
+})
+
+test('Should correctly do type-level field authorization', async () => {
+  const mod = await importFuse()
+  const { builder, addAuthScopes, node } = mod
+  addAuthScopes((ctx) => ({
+    canAccessUser: (id) => {
+      return ctx.allowedIds.includes(id)
+    },
+  }))
+
+  node({
+    name: 'User',
+    authScopes: (parent, args) => ({ canAccessUser: parent.id || args.id }),
+    load(ids) {
+      return [{ id: ids[0], name: 'Test' }]
+    },
+    fields: (t) => ({
+      name: t.exposeString('name'),
+    }),
+  })
+
+  const schema = builder.toSchema()
+
+  const document = parse(`query {
+    node(id: "VXNlcjox") {
+      ... on User { id name }
+    }
+  }`)
+  let result = (await execute({
+    document,
+    schema,
+    contextValue: {
+      allowedIds: [],
+    },
+  })) as { data?: any; errors?: any }
+
+  expect(result.data).toEqual({ node: null })
+  expect(result.errors).toBeDefined()
+  expect(result.errors).toHaveLength(2)
+  expect(result.errors[0].message).toEqual('Not authorized')
+  expect(result.errors[0].path).toEqual(['node', 'name'])
+  expect(result.errors[0].extensions).toEqual({
+    code: 'FORBIDDEN',
+  })
+  expect(result.errors[1].message).toEqual('Not authorized')
+  expect(result.errors[1].path).toEqual(['node', 'id'])
+  expect(result.errors[1].extensions).toEqual({
+    code: 'FORBIDDEN',
+  })
+
+  const alternativeEntry = parse(`query {
+    user(id: "VXNlcjox") {
+      id name
+    }
+  }`)
+  result = (await execute({
+    document: alternativeEntry,
+    schema,
+    contextValue: {
+      allowedIds: [],
+    },
+  })) as { data?: any; errors?: any }
+
+  expect(result.data).toEqual({ user: null })
+  expect(result.errors).toBeDefined()
+  expect(result.errors).toHaveLength(2)
+  expect(result.errors[0].message).toEqual('Not authorized')
+  expect(result.errors[0].path).toEqual(['user', 'name'])
+  expect(result.errors[0].extensions).toEqual({
+    code: 'FORBIDDEN',
+  })
+  expect(result.errors[1].message).toEqual('Not authorized')
+  expect(result.errors[1].path).toEqual(['user', 'id'])
+  expect(result.errors[1].extensions).toEqual({
+    code: 'FORBIDDEN',
+  })
+
+  result = (await execute({
+    document,
+    schema,
+    contextValue: {
+      allowedIds: ['1'],
+    },
+  })) as { data?: any; errors?: any }
+
+  expect(result.data).toEqual({
+    node: {
+      id: 'VXNlcjox',
+      name: 'Test',
+    },
+  })
+})
+
+test('Should correctly do nested field-level authorization', async () => {
+  const mod = await importFuse()
+  const { builder, addQueryFields, addAuthScopes, node } = mod
+  addAuthScopes((ctx) => ({
+    canAccessUser: (id) => {
+      return ctx.allowedIds.includes(id)
+    },
+    isAdmin: !!ctx.isAdmin,
+  }))
+
+  node({
+    name: 'User',
+    authScopes: (parent, args) => ({ canAccessUser: parent.id || args.id }),
+    load(ids) {
+      return [{ id: ids[0], name: 'Test', sensitiveAdminField: 'secret' }]
+    },
+    fields: (t) => ({
+      name: t.exposeString('name'),
+      sensitiveAdminField: t.exposeString('sensitiveAdminField', {
+        authScopes: { isAdmin: true },
+      }),
+    }),
+  })
+
+  const schema = builder.toSchema()
+
+  const document = parse(`query {
+    node(id: "VXNlcjox") {
+      ... on User { id name sensitiveAdminField }
+    }
+  }`)
+  let result = (await execute({
+    document,
+    schema,
+    contextValue: {
+      allowedIds: ['1'],
+    },
+  })) as { data?: any; errors?: any }
+
+  expect(result.data).toEqual({
+    node: {
+      id: 'VXNlcjox',
+      name: 'Test',
+      sensitiveAdminField: null,
+    },
+  })
+  expect(result.errors).toBeDefined()
+  expect(result.errors).toHaveLength(1)
+  expect(result.errors[0].message).toEqual('Not authorized')
+  expect(result.errors[0].path).toEqual(['node', 'sensitiveAdminField'])
+  expect(result.errors[0].extensions).toEqual({
+    code: 'FORBIDDEN',
+  })
+
+  result = (await execute({
+    document,
+    schema,
+    contextValue: {
+      allowedIds: ['1'],
+      isAdmin: true,
+    },
+  })) as { data?: any; errors?: any }
+
+  expect(result.data).toEqual({
+    node: {
+      id: 'VXNlcjox',
+      name: 'Test',
+      sensitiveAdminField: 'secret',
+    },
+  })
 })

--- a/packages/core/test/authorization.test.ts
+++ b/packages/core/test/authorization.test.ts
@@ -8,8 +8,8 @@ const importFuse = () => {
 
 test('Should correctly do top-level field authorization', async () => {
   const mod = await importFuse()
-  const { builder, addQueryFields, addAuthScopes } = mod
-  addAuthScopes((ctx) => ({ isLoggedIn: !!ctx.user }))
+  const { builder, addQueryFields, defineAuthScopes } = mod
+  defineAuthScopes((ctx) => ({ isLoggedIn: !!ctx.user }))
 
   addQueryFields((t) => ({
     isLoggedIn: t.field({
@@ -54,8 +54,8 @@ test('Should correctly do top-level field authorization', async () => {
 
 test('Should correctly do type-level field authorization', async () => {
   const mod = await importFuse()
-  const { builder, addAuthScopes, node } = mod
-  addAuthScopes((ctx) => ({
+  const { builder, defineAuthScopes, node } = mod
+  defineAuthScopes((ctx) => ({
     canAccessUser: (id) => {
       return ctx.allowedIds.includes(id)
     },
@@ -146,8 +146,8 @@ test('Should correctly do type-level field authorization', async () => {
 
 test('Should correctly do nested field-level authorization', async () => {
   const mod = await importFuse()
-  const { builder, addQueryFields, addAuthScopes, node } = mod
-  addAuthScopes((ctx) => ({
+  const { builder, addQueryFields, defineAuthScopes, node } = mod
+  defineAuthScopes((ctx) => ({
     canAccessUser: (id) => {
       return ctx.allowedIds.includes(id)
     },

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -31,6 +31,7 @@ export default defineConfig(async () => {
       dts: {
         entry: 'src/builder.ts',
         banner: `import '@pothos/core'
+import '@pothos/plugin-scope-auth'
 import '@pothos/plugin-dataloader'
 import '@pothos/plugin-relay'`,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       '@pothos/plugin-relay':
         specifier: ^3.44.0
         version: 3.44.0(@pothos/core@3.38.0)(graphql@16.8.1)
+      '@pothos/plugin-scope-auth':
+        specifier: ^3.20.0
+        version: 3.20.0(@pothos/core@3.38.0)(graphql@16.8.1)
       '@urql/core':
         specifier: ^4.2.0
         version: 4.2.0(graphql@16.8.1)
@@ -4159,6 +4162,16 @@ packages:
 
   /@pothos/plugin-relay@3.44.0(@pothos/core@3.38.0)(graphql@16.8.1):
     resolution: {integrity: sha512-7eOsgKL2qCQ+/hHpye4sNNbR2mYogDXPWpQboqniYvUdOjez3VDYjAuOn8Ntw73kZQF0N1iloZPikhCxvY7xuw==}
+    peerDependencies:
+      '@pothos/core': '*'
+      graphql: '>=15.1.0'
+    dependencies:
+      '@pothos/core': 3.38.0(graphql@16.8.1)
+      graphql: 16.8.1
+    dev: false
+
+  /@pothos/plugin-scope-auth@3.20.0(@pothos/core@3.38.0)(graphql@16.8.1):
+    resolution: {integrity: sha512-yaAWScp6ob5uG9Ob8YMTTga8DECANx5HW9q/bz4r66RifO/ZNEr1szXl6WpuyhqhGdasvTpzoYakVrYgs8J8wQ==}
     peerDependencies:
       '@pothos/core': '*'
       graphql: '>=15.1.0'

--- a/website/src/pages/docs/basics/_meta.json
+++ b/website/src/pages/docs/basics/_meta.json
@@ -6,5 +6,6 @@
   "objects-enums-unions-interfaces": "Objects, Enums, Unions, and Interfaces",
   "context": "Context",
   "error-handling": "Error handling",
+  "authorization": "Authorization",
   "mocking": "Mocking data"
 }

--- a/website/src/pages/docs/basics/authorization.mdx
+++ b/website/src/pages/docs/basics/authorization.mdx
@@ -1,0 +1,91 @@
+# Authorization
+
+In some cases you might not be able to fully rely on your datasource to perform
+authorization like in the case of a database or you want to optimise to terminate
+requests as soon as possible.
+
+In these cases you can use `auth-scopes` to perform authorization both on field- as well
+as type-level.
+
+## Setting up
+
+To use the `auth-scopes` we'll need to create a new file in `types/` where we'll
+define the type for our scope as well as how to resolve it.
+
+```ts
+import 'fuse'
+import { defineAuthScopes, Scopes } from 'fuse'
+
+declare module 'fuse' {
+  export interface Scopes {
+    isLoggedIn: boolean
+  }
+}
+
+defineAuthScopes<Scopes>((ctx) => ({
+  isLoggedIn: !!ctx.user,
+  isAdmin: !!ctx.admin,
+  canAccessUser: (userId) => ctx.allowedIds.includes(userId)
+}))
+```
+
+In the above we define two scopes, one named `isLoggedIn` so we can protect all of our
+data and one named `canAccessUser` so we can protect specific fields, we don't want to
+i.e. allow anyone to query our underlying datasource through `Query.user`.
+
+An important part here is that we are using [the context](./context) so we can't forget
+to define the `user` and `allowedIds` on the context when we are executing our request.
+
+## Using scopes
+
+Now that we have defined our scopes we can use them in our schema
+
+```ts
+import { node } from 'fuse';
+
+const UserNode = node<
+  UserSource,
+>({
+  name: 'User',
+  // These functions allow you to do full logic i.e. you can also return
+  // scopes conditionally based on some super-admin privilege where you
+  // just do return true; instead of return {}
+  authScopes: (parent, args) => ({ canAccessUser: parent.id || args.id }),
+  load: async (ids) => getUsers(ids),
+  fields: (t) => ({
+    name: t.exposeString('name'),
+    avatarUrl: t.exposeString('avatarUrl'),
+    secretField: t.exposeString('secretField', {
+      authScopes: { isAdmin: true },
+    }),
+  }),
+})
+```
+
+Now anytime we query `Query.node(id: ID!)` or `Query.user(id: ID!)` we will check if the
+consumer of said request is allowed to access a given `id`. When we request `secretField`
+we will check if the consumer is an admin, if they're not but they are allowed to access the user
+because it's a nullable field it will show up as `null` but the other fields will be resolved
+correctly.
+
+Linear to this we can define our scopes on the query-field level
+
+```ts
+import { addQueryFields } from 'fuse';
+
+addQueryFields((t) => ({
+  isLoggedIn: t.field({
+    type: 'Boolean',
+    description: 'An authentication check',
+    authScopes: {
+      isLoggedIn: true,
+    },
+    resolve: () => {
+      return true
+    },
+  }),
+}))
+```
+
+> Note that using complex values as an input to auth-scope functions will result in
+> lower performance as we can't generate effective cache-keys for them.


### PR DESCRIPTION
This implements [Auth Scopes](https://pothos-graphql.dev/docs/plugins/scope-auth) into `fuse`, this uses a global type (Thanks @hayes) to extend the `Scopes` we define in `builder.ts` and allows you to incrementally grow the scopes.

> This method could also be used to define a global `Context` type in the future!

This needs a few additional things to be feature-complete, an awful lot of tests and documentation!

<details>
  <summary>How this can look in an appliation</summary>

```ts
import 'fuse'
import { addAuthScopes, Scopes } from 'fuse'

declare module 'fuse' {
  export interface Scopes {
    isAuthenticated: boolean
    canAccessEntity: (id: string) => boolean
  }
}

addAuthScopes<Scopes>((ctx) => ({
  isAuthenticated: !!ctx.user,
  canAccessEntity: (entityId) => {
    await assertUserCanAcessEntity(entityId, ctx.user)
    return true;
  }
}))
```

```ts
export const EntityNode = node({
  name: 'Entity',
  authScopes: (entity) => ({ canAccessEntity: entity.id })
})

// similar on a field we can do
authScopes: (entity) => ({ canAccessEntity: args.id })

// or
authScopes: { isAuthenticated: true }
```
[grantScopes](https://pothos-graphql.dev/docs/plugins/scope-auth#granting-access-to-a-resource-based-on-how-it-is-accessed) could also be interesting for the cascade
</details>

Resolves #12 