### PR TITLE
fix(next): avoid duplicate codegen processes

### DIFF
--- a/.changeset/little-rice-remember.md
+++ b/.changeset/little-rice-remember.md
@@ -1,0 +1,5 @@
+---
+'fuse': patch
+---
+
+Avoid starting two codegen processes when reloading next-config

--- a/packages/core/src/next/plugin.ts
+++ b/packages/core/src/next/plugin.ts
@@ -10,8 +10,8 @@ interface Options {
   path?: string
 }
 
+let isRunningCodegen = false
 export function nextFusePlugin(options: Options = {}) {
-  let isRunningCodegen = false
   return (nextConfig: any = {}): any => {
     if (process.env.NODE_ENV === 'development' && !isRunningCodegen) {
       boostrapFuse()


### PR DESCRIPTION
When reloading the next config we could introduce duplicate codegen processes